### PR TITLE
Feature/8 add comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,5 @@ ide-helper:
 	docker compose exec app php artisan ide-helper:generate
 	docker compose exec app php artisan ide-helper:meta
 	docker compose exec app php artisan ide-helper:models --nowrite
+pint :
+	docker compose exec app ./vendor/bin/pint

--- a/src/app/Http/Controllers/CommentController.php
+++ b/src/app/Http/Controllers/CommentController.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Models\Comment;
 use App\Http\Resources\CommentResource;
-use App\Http\Requests\CommentRequest;
+use App\Models\Comment;
 use App\Services\Comment\CreateComment;
 use App\Services\Comment\UpdateComment;
-
+use Illuminate\Http\Request;
 
 class CommentController extends Controller
 {
@@ -58,7 +58,7 @@ class CommentController extends Controller
      */
     public function destroy(string $id)
     {
-        $comment =Comment::find($id)->delete();
+        $comment = Comment::find($id)->delete();
 
         return response()->json([
             $comment,

--- a/src/app/Http/Controllers/CommentController.php
+++ b/src/app/Http/Controllers/CommentController.php
@@ -27,22 +27,14 @@ class CommentController extends Controller
      */
     public function store(Request $request)
     {
-        // $validated = $request->validated();
-
-        // $created = Comment::create($validated);
-        // $created->article_id = $request->match_post_id;
-        // $created->user_id = auth()->user()->id;
-
-        // return new CommentResource($created);
-
         $comment = app(CreateComment::class)->execute([
             'user_id' => auth()->user()->id,
             'match_post_id' => $request->match_post_id,
+            'root_id' => $request->input('root_id'),
             'content' => $request->input('content'),
         ]);
 
         return new CommentResource($comment);
-
     }
 
     /**
@@ -50,16 +42,11 @@ class CommentController extends Controller
      */
     public function update(Request $request, Comment $comment)
     {
-        // $comment = Comment::find($id);
-        // $validated = $request->validated();
-        // $comment->fill($validated)->save();
-
-        // return new CommentResource($comment);
-
         $comments = app(UpdateComment::class)->execute([
             'user_id' => auth()->user()->id,
             'comment_id' => $comment->id,
             'match_post_id' => $request->match_post_id,
+            'root_id' => $request->root_id,
             'content' => $request->input('content'),
         ]);
 

--- a/src/app/Http/Controllers/CommentController.php
+++ b/src/app/Http/Controllers/CommentController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Comment;
+use App\Http\Resources\CommentResource;
+use App\Http\Requests\CommentRequest;
+use App\Services\Comment\CreateComment;
+use App\Services\Comment\UpdateComment;
+
+
+class CommentController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $comments = Comment::all();
+
+        return CommentResource::collection($comments);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        // $validated = $request->validated();
+
+        // $created = Comment::create($validated);
+        // $created->article_id = $request->match_post_id;
+        // $created->user_id = auth()->user()->id;
+
+        // return new CommentResource($created);
+
+        $comment = app(CreateComment::class)->execute([
+            'user_id' => auth()->user()->id,
+            'match_post_id' => $request->match_post_id,
+            'content' => $request->input('content'),
+        ]);
+
+        return new CommentResource($comment);
+
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Comment $comment)
+    {
+        // $comment = Comment::find($id);
+        // $validated = $request->validated();
+        // $comment->fill($validated)->save();
+
+        // return new CommentResource($comment);
+
+        $comments = app(UpdateComment::class)->execute([
+            'user_id' => auth()->user()->id,
+            'comment_id' => $comment->id,
+            'match_post_id' => $request->match_post_id,
+            'content' => $request->input('content'),
+        ]);
+
+        return new CommentResource($comments);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $comment =Comment::find($id)->delete();
+
+        return response()->json([
+            $comment,
+            'message' => 'コメントを削除しました',
+        ], 200);
+    }
+}

--- a/src/app/Http/Controllers/MatchPostController.php
+++ b/src/app/Http/Controllers/MatchPostController.php
@@ -48,7 +48,7 @@ class MatchPostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateMatchPostRequest $request, string $id, User $user)
+    public function update(UpdateMatchPostRequest $request, string $id)
     {
         $matchPost = MatchPost::find($id);
         $validated = $request->validated();

--- a/src/app/Http/Controllers/MatchPostController.php
+++ b/src/app/Http/Controllers/MatchPostController.php
@@ -8,7 +8,6 @@ use App\Http\Requests\StoreMatchPostRequest;
 use App\Http\Requests\UpdateMatchPostRequest;
 use App\Http\Resources\MatchPostResource;
 use App\Models\MatchPost;
-use App\Models\User;
 
 class MatchPostController extends Controller
 {

--- a/src/app/Http/Resources/CommentResource.php
+++ b/src/app/Http/Resources/CommentResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Resources;
 
 use Carbon\Carbon;

--- a/src/app/Http/Resources/CommentResource.php
+++ b/src/app/Http/Resources/CommentResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CommentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $created_at = new Carbon($this->created_at);
+        $updated_at = new Carbon($this->updated_at);
+
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'match_post_id' => $this->match_post_id,
+            'content' => $this->content,
+            'created_at' => $created_at->format('Y/m/d H:i'),
+            'updated_at' => $updated_at->format('Y/m/d H:i'),
+        ];
+    }
+}

--- a/src/app/Http/Resources/CommentResource.php
+++ b/src/app/Http/Resources/CommentResource.php
@@ -22,6 +22,7 @@ class CommentResource extends JsonResource
             'id' => $this->id,
             'user_id' => $this->user_id,
             'match_post_id' => $this->match_post_id,
+            'root_id' => $this->root_id,
             'content' => $this->content,
             'created_at' => $created_at->format('Y/m/d H:i'),
             'updated_at' => $updated_at->format('Y/m/d H:i'),

--- a/src/app/Models/Comment.php
+++ b/src/app/Models/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/src/app/Models/Comment.php
+++ b/src/app/Models/Comment.php
@@ -12,6 +12,7 @@ class Comment extends Model
     protected $fillable = [
         'content',
         'match_post_id',
+        'root_id',
         'user_id',
     ];
 
@@ -23,5 +24,10 @@ class Comment extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function replies()
+    {
+        return $this->hasMany(Comment::class, 'root_id');
     }
 }

--- a/src/app/Models/Comment.php
+++ b/src/app/Models/Comment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'content',
+        'match_post_id',
+        'user_id',
+    ];
+
+    public function matchPost()
+    {
+        return $this->belongsTo(MatchPost::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/MatchPost.php
+++ b/src/app/Models/MatchPost.php
@@ -33,6 +33,11 @@ class MatchPost extends Model
         return $this->belongsTo(Mood::class);
     }
 
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
     protected static function boot()
     {
         parent::boot();

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -48,4 +48,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(MatchPost::class);
     }
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
 }

--- a/src/app/Services/BaseService.php
+++ b/src/app/Services/BaseService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+abstract class BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [];
+    }
+
+    /**
+     * Validate all datas to execute the service.
+     *
+     * @param  array  $data
+     * @return bool
+     */
+    public function validate(array $data): bool
+    {
+        Validator::make($data, $this->rules())
+            ->validate();
+
+        return true;
+    }
+
+    /**
+     * Checks if the value is empty or null.
+     *
+     * @param  mixed  $data
+     * @param  mixed  $index
+     * @return mixed
+     */
+    public function nullOrValue($data, $index)
+    {
+        $value = Arr::get($data, $index, null);
+
+        return is_null($value) || $value === '' ? null : $value;
+    }
+
+    /**
+     * Checks if the value is empty or null and returns a date from a string.
+     *
+     * @param  mixed  $data
+     * @param  mixed  $index
+     * @return mixed
+     */
+    public function nullOrDate($data, $index)
+    {
+        $value = Arr::get($data, $index, null);
+
+        return is_null($value) || $value === '' ? null : Carbon::parse($value);
+    }
+
+    /**
+     * Returns the value if it's defined, or false otherwise.
+     *
+     * @param  mixed  $data
+     * @param  mixed  $index
+     * @return mixed
+     */
+    public function valueOrFalse($data, $index)
+    {
+        if (empty($data[$index])) {
+            return false;
+        }
+
+        return $data[$index];
+    }
+}

--- a/src/app/Services/BaseService.php
+++ b/src/app/Services/BaseService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use Carbon\Carbon;
@@ -20,9 +22,6 @@ abstract class BaseService
 
     /**
      * Validate all datas to execute the service.
-     *
-     * @param  array  $data
-     * @return bool
      */
     public function validate(array $data): bool
     {
@@ -34,10 +33,6 @@ abstract class BaseService
 
     /**
      * Checks if the value is empty or null.
-     *
-     * @param  mixed  $data
-     * @param  mixed  $index
-     * @return mixed
      */
     public function nullOrValue($data, $index)
     {
@@ -48,10 +43,6 @@ abstract class BaseService
 
     /**
      * Checks if the value is empty or null and returns a date from a string.
-     *
-     * @param  mixed  $data
-     * @param  mixed  $index
-     * @return mixed
      */
     public function nullOrDate($data, $index)
     {
@@ -62,10 +53,6 @@ abstract class BaseService
 
     /**
      * Returns the value if it's defined, or false otherwise.
-     *
-     * @param  mixed  $data
-     * @param  mixed  $index
-     * @return mixed
      */
     public function valueOrFalse($data, $index)
     {

--- a/src/app/Services/Comment/CreateComment.php
+++ b/src/app/Services/Comment/CreateComment.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Comment;
 
-use App\Services\BaseService;
 use App\Models\Comment;
+use App\Services\BaseService;
 
 class CreateComment extends BaseService
 {
@@ -19,16 +21,17 @@ class CreateComment extends BaseService
 
     public function execute(array $data): Comment
     {
-
         $this->validate($data);
 
         $rootComment = Comment::find($data['root_id']);
 
-        if($rootComment) {
+        if ($rootComment) {
             $reply = $rootComment->replies()->create($data);
+
             return Comment::find($reply->id);
         } else {
             $comment = Comment::create($data);
+
             return Comment::find($comment->id);
         }
     }

--- a/src/app/Services/Comment/CreateComment.php
+++ b/src/app/Services/Comment/CreateComment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services\Comment;
+
+use App\Services\BaseService;
+use App\Models\Comment;
+
+class CreateComment extends BaseService
+{
+    public function rules()
+    {
+        return [
+            'user_id' => 'required|integer|exists:users,id',
+            'match_post_id' => 'required|integer|exists:match_posts,id',
+            'content' => 'required|string|min:1|max:255',
+        ];
+    }
+
+    public function execute(array $data): Comment
+    {
+        $this->validate($data);
+
+        $comment = Comment::create($data);
+
+        return Comment::find($comment->id);
+    }
+}

--- a/src/app/Services/Comment/CreateComment.php
+++ b/src/app/Services/Comment/CreateComment.php
@@ -12,16 +12,24 @@ class CreateComment extends BaseService
         return [
             'user_id' => 'required|integer|exists:users,id',
             'match_post_id' => 'required|integer|exists:match_posts,id',
+            'root_id' => 'nullable',
             'content' => 'required|string|min:1|max:255',
         ];
     }
 
     public function execute(array $data): Comment
     {
+
         $this->validate($data);
 
-        $comment = Comment::create($data);
+        $rootComment = Comment::find($data['root_id']);
 
-        return Comment::find($comment->id);
+        if($rootComment) {
+            $reply = $rootComment->replies()->create($data);
+            return Comment::find($reply->id);
+        } else {
+            $comment = Comment::create($data);
+            return Comment::find($comment->id);
+        }
     }
 }

--- a/src/app/Services/Comment/UpdateComment.php
+++ b/src/app/Services/Comment/UpdateComment.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Comment;
 
-use App\Services\BaseService;
 use App\Models\Comment;
+use App\Services\BaseService;
 
 class UpdateComment extends BaseService
 {
@@ -20,7 +22,6 @@ class UpdateComment extends BaseService
 
     public function execute(array $data): Comment
     {
-
         $this->validate($data);
 
         if (! empty($data['match_post_id'])) {

--- a/src/app/Services/Comment/UpdateComment.php
+++ b/src/app/Services/Comment/UpdateComment.php
@@ -13,6 +13,7 @@ class UpdateComment extends BaseService
             'user_id' => 'required|integer|exists:users,id',
             'match_post_id' => 'required|integer|exists:match_posts,id',
             'comment_id' => 'required|integer|exists:comments,id',
+            'root_id' => 'integer|nullable',
             'content' => 'required|string|min:1|max:255',
         ];
     }
@@ -32,10 +33,10 @@ class UpdateComment extends BaseService
         }
 
         $comment->update([
-            'title' => $data['content'],
+            'content' => $data['content'],
         ]);
 
-        $comment = Comment::create($data);
+        $comment->fill($data)->save();
 
         return $comment;
     }

--- a/src/app/Services/Comment/UpdateComment.php
+++ b/src/app/Services/Comment/UpdateComment.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Comment;
+
+use App\Services\BaseService;
+use App\Models\Comment;
+
+class UpdateComment extends BaseService
+{
+    public function rules()
+    {
+        return [
+            'user_id' => 'required|integer|exists:users,id',
+            'match_post_id' => 'required|integer|exists:match_posts,id',
+            'comment_id' => 'required|integer|exists:comments,id',
+            'content' => 'required|string|min:1|max:255',
+        ];
+    }
+
+    public function execute(array $data): Comment
+    {
+
+        $this->validate($data);
+
+        if (! empty($data['match_post_id'])) {
+            $comment = Comment::where('user_id', $data['user_id'])
+                ->where('match_post_id', $data['match_post_id'])
+                ->findOrFail($data['comment_id']);
+        } else {
+            $comment = Comment::where('user_id', $data['user_id'])
+                ->findOrFail($data['comment_id']);
+        }
+
+        $comment->update([
+            'title' => $data['content'],
+        ]);
+
+        $comment = Comment::create($data);
+
+        return $comment;
+    }
+}

--- a/src/database/migrations/2023_03_24_083206_create_comments_table.php
+++ b/src/database/migrations/2023_03_24_083206_create_comments_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/src/database/migrations/2023_03_24_083206_create_comments_table.php
+++ b/src/database/migrations/2023_03_24_083206_create_comments_table.php
@@ -22,6 +22,10 @@ return new class extends Migration
                 ->constrained('users')
                 ->cascadeOnDelete()
                 ->cascadeOnUpdate();
+            $table->foreignId('root_id')
+                ->constrained('comments')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
             $table->timestamps();
         });
     }

--- a/src/database/migrations/2023_03_24_083206_create_comments_table.php
+++ b/src/database/migrations/2023_03_24_083206_create_comments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->string('content');
+            $table->foreignId('match_post_id')
+                ->constrained('match_posts')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/src/database/migrations/2023_03_24_134415_add_nullabe_to_comments_table.php
+++ b/src/database/migrations/2023_03_24_134415_add_nullabe_to_comments_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/src/database/migrations/2023_03_24_134415_add_nullabe_to_comments_table.php
+++ b/src/database/migrations/2023_03_24_134415_add_nullabe_to_comments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->foreignId('root_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->foreignId('root_id')->nullable(false)->change();
+        });
+    }
+};

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\MatchPostController;
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\MatchPostController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -38,4 +38,3 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('/comment', CommentController::class)
         ->only(['store', 'update', 'destroy']);
 });
-

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\MatchPostController;
+use App\Http\Controllers\CommentController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -25,9 +26,16 @@ Route::apiResource('/match_posts', MatchPostController::class)
     ->only(['index']);
 
 Route::apiResource('/match_post', MatchPostController::class)
-->only(['show']);
+    ->only(['show']);
+
+Route::apiResource('/comments', CommentController::class)
+    ->only(['index']);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('/match_post', MatchPostController::class)
         ->only(['store', 'update', 'destroy']);
+
+    Route::apiResource('/comment', CommentController::class)
+        ->only(['store', 'update', 'destroy']);
 });
+


### PR DESCRIPTION
## ISSUE

Closes #8 

## 概要

- コメント機能を実装
- コメント返信機能を実装

## 変更内容

-  コメント機能



-  返信機能

今回のサービスでは、以下のようにコメント1のスレッド的な考え方で十分だと思い、`root_id` をコメントテーブルに追加して、`root_id`が`null`だったら親コメント、`root_id`に親コメントの`id`を入れたものを子コメントとした。

コメント1
  ∟ コメント2
  ∟ コメント3

